### PR TITLE
Since v0.8.11 Protobuf requires Gradle >5.6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip


### PR DESCRIPTION
See: https://github.com/google/protobuf-gradle-plugin/releases/tag/v0.8.11